### PR TITLE
Cleanup of EDA.ipynb

### DIFF
--- a/EDA.ipynb
+++ b/EDA.ipynb
@@ -1582,7 +1582,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/EDA.ipynb
+++ b/EDA.ipynb
@@ -4,13 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Data Understanding\n",
-    "\n"
+    "# EDA & Cleaning\n",
+    "\n",
+    "### In this notebook we perform the first three steps of the CRISP-DM process: business understanding, data understanding, and data preparation."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,12 +21,13 @@
     "%matplotlib inline\n",
     "import sqlalchemy\n",
     "import psycopg2\n",
-    "from sklearn.model_selection import train_test_split"
+    "from sklearn.model_selection import train_test_split\n",
+    "from helper import human_readify"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -34,7 +36,7 @@
        "['resultsdata13', 'sampledata13']"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -46,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -213,7 +215,7 @@
        "4                                              ND     805   35\\r\\n  "
       ]
      },
-     "execution_count": 60,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -226,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -272,12 +274,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Drop irrelevant attributes that are only about lab testing methods: `confmethod`, `confmethod2`, and `testclass`."
+    "### Drop irrelevant attributes that are only about lab testing methods: `confmethod`, `confmethod2`, and `testclass`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -435,7 +437,7 @@
        "4              ND     805   35\\r\\n  "
       ]
      },
-     "execution_count": 64,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -467,7 +469,7 @@
        "Name: annotate, dtype: int64"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -478,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -500,7 +502,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -511,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -520,7 +522,7 @@
        "True"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,12 +535,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice our target attribute has many missing values, encoded as empty strings rather than null values. We drop those. "
+    "### Notice our target attribute has many missing values, encoded as empty strings rather than null values. We drop those and then correct the row indices to go from 0 to n again. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = results[results['annotate'] != '']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -579,7 +590,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>50238</th>\n",
+       "      <th>0</th>\n",
        "      <td>239</td>\n",
        "      <td>AJ</td>\n",
        "      <td>RE</td>\n",
@@ -595,7 +606,7 @@
        "      <td>35\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>249096</th>\n",
+       "      <th>1</th>\n",
        "      <td>1183</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -611,7 +622,7 @@
        "      <td>52\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>251475</th>\n",
+       "      <th>2</th>\n",
        "      <td>1196</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -627,7 +638,7 @@
        "      <td>52\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>257567</th>\n",
+       "      <th>3</th>\n",
        "      <td>1230</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -643,7 +654,7 @@
        "      <td>35\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>264693</th>\n",
+       "      <th>4</th>\n",
        "      <td>1269</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -663,28 +674,29 @@
        "</div>"
       ],
       "text/plain": [
-       "        sample_pk commod commtype  lab pestcode concen    lod conunit  \\\n",
-       "50238         239     AJ       RE  WA1      083  0.008  0.005       M   \n",
-       "249096       1183     BR       FR  FL1      AFU  0.011  0.010       M   \n",
-       "251475       1196     BR       FR  FL1      AFU  0.013  0.010       M   \n",
-       "257567       1230     BR       FR  FL1      144  0.035  0.005       M   \n",
-       "264693       1269     BR       FR  FL1      180  0.026  0.010       M   \n",
+       "   sample_pk commod commtype  lab pestcode concen    lod conunit annotate  \\\n",
+       "0        239     AJ       RE  WA1      083  0.008  0.005       M        Q   \n",
+       "1       1183     BR       FR  FL1      AFU  0.011  0.010       M        V   \n",
+       "2       1196     BR       FR  FL1      AFU  0.013  0.010       M        V   \n",
+       "3       1230     BR       FR  FL1      144  0.035  0.005       M        V   \n",
+       "4       1269     BR       FR  FL1      180  0.026  0.010       M        V   \n",
        "\n",
-       "       annotate quantitate mean extract determin  \n",
-       "50238         Q               O     805   35\\r\\n  \n",
-       "249096        V               O     805   52\\r\\n  \n",
-       "251475        V               O     805   52\\r\\n  \n",
-       "257567        V               O     805   35\\r\\n  \n",
-       "264693        V               O     805   52\\r\\n  "
+       "  quantitate mean extract determin  \n",
+       "0               O     805   35\\r\\n  \n",
+       "1               O     805   52\\r\\n  \n",
+       "2               O     805   52\\r\\n  \n",
+       "3               O     805   35\\r\\n  \n",
+       "4               O     805   52\\r\\n  "
       ]
      },
-     "execution_count": 68,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "results = results[results['annotate'] != '']\n",
+    "results.reset_index(inplace=True)\n",
+    "results.drop('index', axis=1, inplace=True)\n",
     "results.head()"
    ]
   },
@@ -692,12 +704,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mean is a terrible name for a column, so we'll rename it."
+    "### Mean is a terrible name for a column, so we'll rename it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -738,7 +750,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>50238</th>\n",
+       "      <th>0</th>\n",
        "      <td>239</td>\n",
        "      <td>AJ</td>\n",
        "      <td>RE</td>\n",
@@ -754,7 +766,7 @@
        "      <td>35\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>249096</th>\n",
+       "      <th>1</th>\n",
        "      <td>1183</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -770,7 +782,7 @@
        "      <td>52\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>251475</th>\n",
+       "      <th>2</th>\n",
        "      <td>1196</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -786,7 +798,7 @@
        "      <td>52\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>257567</th>\n",
+       "      <th>3</th>\n",
        "      <td>1230</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -802,7 +814,7 @@
        "      <td>35\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>264693</th>\n",
+       "      <th>4</th>\n",
        "      <td>1269</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -822,22 +834,22 @@
        "</div>"
       ],
       "text/plain": [
-       "        sample_pk commod commtype  lab pestcode concen    lod conunit  \\\n",
-       "50238         239     AJ       RE  WA1      083  0.008  0.005       M   \n",
-       "249096       1183     BR       FR  FL1      AFU  0.011  0.010       M   \n",
-       "251475       1196     BR       FR  FL1      AFU  0.013  0.010       M   \n",
-       "257567       1230     BR       FR  FL1      144  0.035  0.005       M   \n",
-       "264693       1269     BR       FR  FL1      180  0.026  0.010       M   \n",
+       "   sample_pk commod commtype  lab pestcode concen    lod conunit annotate  \\\n",
+       "0        239     AJ       RE  WA1      083  0.008  0.005       M        Q   \n",
+       "1       1183     BR       FR  FL1      AFU  0.011  0.010       M        V   \n",
+       "2       1196     BR       FR  FL1      AFU  0.013  0.010       M        V   \n",
+       "3       1230     BR       FR  FL1      144  0.035  0.005       M        V   \n",
+       "4       1269     BR       FR  FL1      180  0.026  0.010       M        V   \n",
        "\n",
-       "       annotate quantitate avg_detect extract determin  \n",
-       "50238         Q                     O     805   35\\r\\n  \n",
-       "249096        V                     O     805   52\\r\\n  \n",
-       "251475        V                     O     805   52\\r\\n  \n",
-       "257567        V                     O     805   35\\r\\n  \n",
-       "264693        V                     O     805   52\\r\\n  "
+       "  quantitate avg_detect extract determin  \n",
+       "0                     O     805   35\\r\\n  \n",
+       "1                     O     805   52\\r\\n  \n",
+       "2                     O     805   52\\r\\n  \n",
+       "3                     O     805   35\\r\\n  \n",
+       "4                     O     805   52\\r\\n  "
       ]
      },
-     "execution_count": 83,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -855,7 +867,7 @@
     {
      "data": {
       "text/plain": [
-       "(4887, 16)"
+       "(4887, 13)"
       ]
      },
      "execution_count": 15,
@@ -869,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -956,8 +968,8 @@
       "PU      12\n",
       "MU      12\n",
       "PC       5\n",
-      "AJ       1\n",
       "GJ       1\n",
+      "AJ       1\n",
       "Name: commod, dtype: int64\n",
       "FR    3624\n",
       "RE    1128\n",
@@ -1005,36 +1017,36 @@
       "907     41\n",
       "ABQ     40\n",
       "      ... \n",
-      "034      2\n",
-      "AHM      2\n",
-      "B82      2\n",
-      "911      2\n",
-      "AGX      2\n",
-      "512      2\n",
-      "900      2\n",
       "717      2\n",
-      "945      2\n",
-      "A25      2\n",
+      "AHM      2\n",
+      "034      2\n",
+      "701      2\n",
+      "624      2\n",
       "781      2\n",
-      "537      2\n",
-      "AKW      1\n",
-      "718      1\n",
+      "911      2\n",
+      "A25      2\n",
+      "945      2\n",
+      "651      2\n",
+      "900      2\n",
+      "B82      2\n",
+      "AFB      1\n",
+      "956      1\n",
+      "539      1\n",
+      "633      1\n",
+      "125      1\n",
+      "948      1\n",
       "AGT      1\n",
       "173      1\n",
-      "200      1\n",
-      "AJP      1\n",
+      "718      1\n",
       "387      1\n",
-      "125      1\n",
-      "AFS      1\n",
-      "633      1\n",
-      "382      1\n",
-      "539      1\n",
-      "143      1\n",
-      "AFB      1\n",
-      "948      1\n",
-      "956      1\n",
+      "AJP      1\n",
       "908      1\n",
+      "AFS      1\n",
+      "200      1\n",
       "172      1\n",
+      "AKW      1\n",
+      "382      1\n",
+      "143      1\n",
       "Name: pestcode, Length: 149, dtype: int64\n",
       "0.0020    839\n",
       "0.0018    710\n",
@@ -1168,6 +1180,10 @@
       "QV     145\n",
       "X       23\n",
       "Name: annotate, dtype: int64\n",
+      "     4834\n",
+      "P      33\n",
+      "E      20\n",
+      "Name: quantitate, dtype: int64\n",
       "O    4868\n",
       "R      19\n",
       "Name: avg_detect, dtype: int64\n",
@@ -1193,12 +1209,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## `quantitate` column has many missing values, so we'll drop it."
+    "### The `quantitate` column has many missing values, so we'll drop it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1238,7 +1254,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>50238</th>\n",
+       "      <th>0</th>\n",
        "      <td>239</td>\n",
        "      <td>AJ</td>\n",
        "      <td>RE</td>\n",
@@ -1253,7 +1269,7 @@
        "      <td>35\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>249096</th>\n",
+       "      <th>1</th>\n",
        "      <td>1183</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1268,7 +1284,7 @@
        "      <td>52\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>251475</th>\n",
+       "      <th>2</th>\n",
        "      <td>1196</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1283,7 +1299,7 @@
        "      <td>52\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>257567</th>\n",
+       "      <th>3</th>\n",
        "      <td>1230</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1298,7 +1314,7 @@
        "      <td>35\\r\\n</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>264693</th>\n",
+       "      <th>4</th>\n",
        "      <td>1269</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1317,22 +1333,22 @@
        "</div>"
       ],
       "text/plain": [
-       "        sample_pk commod commtype  lab pestcode concen    lod conunit  \\\n",
-       "50238         239     AJ       RE  WA1      083  0.008  0.005       M   \n",
-       "249096       1183     BR       FR  FL1      AFU  0.011  0.010       M   \n",
-       "251475       1196     BR       FR  FL1      AFU  0.013  0.010       M   \n",
-       "257567       1230     BR       FR  FL1      144  0.035  0.005       M   \n",
-       "264693       1269     BR       FR  FL1      180  0.026  0.010       M   \n",
+       "   sample_pk commod commtype  lab pestcode concen    lod conunit annotate  \\\n",
+       "0        239     AJ       RE  WA1      083  0.008  0.005       M        Q   \n",
+       "1       1183     BR       FR  FL1      AFU  0.011  0.010       M        V   \n",
+       "2       1196     BR       FR  FL1      AFU  0.013  0.010       M        V   \n",
+       "3       1230     BR       FR  FL1      144  0.035  0.005       M        V   \n",
+       "4       1269     BR       FR  FL1      180  0.026  0.010       M        V   \n",
        "\n",
-       "       annotate avg_detect extract determin  \n",
-       "50238         Q          O     805   35\\r\\n  \n",
-       "249096        V          O     805   52\\r\\n  \n",
-       "251475        V          O     805   52\\r\\n  \n",
-       "257567        V          O     805   35\\r\\n  \n",
-       "264693        V          O     805   52\\r\\n  "
+       "  avg_detect extract determin  \n",
+       "0          O     805   35\\r\\n  \n",
+       "1          O     805   52\\r\\n  \n",
+       "2          O     805   52\\r\\n  \n",
+       "3          O     805   35\\r\\n  \n",
+       "4          O     805   52\\r\\n  "
       ]
      },
-     "execution_count": 90,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1344,7 +1360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1352,7 +1368,7 @@
      "output_type": "stream",
      "text": [
       "<class 'pandas.core.frame.DataFrame'>\n",
-      "Int64Index: 4887 entries, 50238 to 1967810\n",
+      "RangeIndex: 4887 entries, 0 to 4886\n",
       "Data columns (total 12 columns):\n",
       "sample_pk     4887 non-null int64\n",
       "commod        4887 non-null object\n",
@@ -1367,7 +1383,7 @@
       "extract       4887 non-null object\n",
       "determin      4887 non-null object\n",
       "dtypes: float64(1), int64(1), object(10)\n",
-      "memory usage: 496.3+ KB\n"
+      "memory usage: 458.2+ KB\n"
      ]
     }
    ],
@@ -1384,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1399,12 +1415,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now `concen` and `conunit` are redundant and misleading, so we'll drop them."
+    "### Now `concen` and `conunit` are redundant and misleading, so we'll drop them."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1443,7 +1459,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>50238</th>\n",
+       "      <th>0</th>\n",
        "      <td>239</td>\n",
        "      <td>AJ</td>\n",
        "      <td>RE</td>\n",
@@ -1457,7 +1473,7 @@
        "      <td>80000.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>249096</th>\n",
+       "      <th>1</th>\n",
        "      <td>1183</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1471,7 +1487,7 @@
        "      <td>110000.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>251475</th>\n",
+       "      <th>2</th>\n",
        "      <td>1196</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1485,7 +1501,7 @@
        "      <td>130000.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>257567</th>\n",
+       "      <th>3</th>\n",
        "      <td>1230</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1499,7 +1515,7 @@
        "      <td>350000.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>264693</th>\n",
+       "      <th>4</th>\n",
        "      <td>1269</td>\n",
        "      <td>BR</td>\n",
        "      <td>FR</td>\n",
@@ -1517,22 +1533,22 @@
        "</div>"
       ],
       "text/plain": [
-       "        sample_pk commod commtype  lab pestcode    lod annotate avg_detect  \\\n",
-       "50238         239     AJ       RE  WA1      083  0.005        Q          O   \n",
-       "249096       1183     BR       FR  FL1      AFU  0.010        V          O   \n",
-       "251475       1196     BR       FR  FL1      AFU  0.010        V          O   \n",
-       "257567       1230     BR       FR  FL1      144  0.005        V          O   \n",
-       "264693       1269     BR       FR  FL1      180  0.010        V          O   \n",
+       "   sample_pk commod commtype  lab pestcode    lod annotate avg_detect extract  \\\n",
+       "0        239     AJ       RE  WA1      083  0.005        Q          O     805   \n",
+       "1       1183     BR       FR  FL1      AFU  0.010        V          O     805   \n",
+       "2       1196     BR       FR  FL1      AFU  0.010        V          O     805   \n",
+       "3       1230     BR       FR  FL1      144  0.005        V          O     805   \n",
+       "4       1269     BR       FR  FL1      180  0.010        V          O     805   \n",
        "\n",
-       "       extract determin  concentration  \n",
-       "50238      805   35\\r\\n        80000.0  \n",
-       "249096     805   52\\r\\n       110000.0  \n",
-       "251475     805   52\\r\\n       130000.0  \n",
-       "257567     805   35\\r\\n       350000.0  \n",
-       "264693     805   52\\r\\n       260000.0  "
+       "  determin  concentration  \n",
+       "0   35\\r\\n        80000.0  \n",
+       "1   52\\r\\n       110000.0  \n",
+       "2   52\\r\\n       130000.0  \n",
+       "3   35\\r\\n       350000.0  \n",
+       "4   52\\r\\n       260000.0  "
       ]
      },
-     "execution_count": 102,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1546,16 +1562,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This looks great, so we'll export as a csv."
+    "### This looks great, so we'll export as a csv."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cleaned_data = results.to_csv('data/cleaned_data.csv')"
+    "results.to_csv('data/cleaned_data.csv', index=False)"
    ]
   },
   {

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,20 @@
+def human_readify(df):
+    map_ = [
+        ('annotate', 'anotate_codes.csv'),
+        ('commod', 'commodity_codes.csv'),
+        ('commtype', 'commod_type_codes.csv'),
+        ('lab', 'lab_codes.csv'), 
+        ('pestcode', 'pest_codes.csv'),
+        ('testclass', 'test_class_codes.csv'), 
+        ('confmethod', 'confmethod_codes.csv'),
+        ('mean', 'mean_codes.csv'),
+        ('extract', 'extract_codes.csv'),
+        ('determin', 'determin_codes.csv')
+    ]
+    for col, csv in map_:
+        with open(f'data/{csv}') as f:
+            for row in f:
+                row = row.split(',')
+                df[col].replace(row[0], row[1])
+                
+    return df


### PR DESCRIPTION
In this branch I performed some light cleanup of EDA.ipynb:

- Corrected indexes of results dataframe
- Polished documentation (consistency of text formatting and phrasing)
- Fixed export to .csv (no longer creates second index column)